### PR TITLE
Add ESM support and dual CJS/ESM exports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,4 +61,10 @@ module.exports = {
     'space-infix-ops': 'error',
     'spaced-comment': [ 'error', 'always', { block: { balanced: true } } ],
   },
+  overrides: [
+    {
+      files: [ './index.mjs' ],
+      parserOptions: { sourceType: 'module' },
+    },
+  ],
 };

--- a/README.md
+++ b/README.md
@@ -16,18 +16,20 @@ new MyError('message', error); // Take a message and an error
 
 ## Contents
 
-* [Features](#features)
-  * [Define custom errors easily](#define-custom-errors-easily)
-  * [Wrap errors without losing any data](#wrap-errors-without-losing-any-data)
-* [Installation](#installation)
-* [Usage](#usage)
-  * [Define custom errors](#define-custom-errors)
-  * [Instantiate custom errors](#instantiate-custom-errors)
-* [Examples](#examples)
-  * [Wrap an error](#wrap-an-error)
-  * [Wrap an error while passing a new message](#wrap-an-error-while-passing-a-new-message)
-* [Special Thanks](#special-thanks)
-* [License](#license)
+- [Extensible Custom Error](#extensible-custom-error)
+  - [Contents](#contents)
+  - [Features](#features)
+    - [Define custom errors easily](#define-custom-errors-easily)
+    - [Wrap errors without losing any data](#wrap-errors-without-losing-any-data)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [Define custom errors](#define-custom-errors)
+    - [Instantiate custom errors](#instantiate-custom-errors)
+  - [Examples](#examples)
+    - [Wrap an error](#wrap-an-error)
+    - [Wrap an error while passing a new message](#wrap-an-error-while-passing-a-new-message)
+  - [Special Thanks](#special-thanks)
+  - [License](#license)
 
 ## Features
 
@@ -83,7 +85,10 @@ $ yarn add extensible-custom-error
 ### Define custom errors
 
 ```js
+// CommonJS
 const ExtensibleCustomError = require('extensible-custom-error');
+// ESM
+// import ExtensibleCustomError from 'extensible-custom-error';
 
 // That's it!
 class MyError extends ExtensibleCustomError {}

--- a/index.cjs
+++ b/index.cjs
@@ -1,0 +1,1 @@
+module.exports = require('./src/index.js');

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,3 @@
+import CJSExport from './index.cjs';
+export default CJSExport;
+export const ExtensibleCustomError = CJSExport;

--- a/package.json
+++ b/package.json
@@ -2,8 +2,17 @@
   "name": "extensible-custom-error",
   "version": "0.0.7",
   "description": "JavaScript extensible custom error that can take a message and/or an Error object",
-  "main": "src/index.js",
+  "main": "./index.cjs",
+  "module": "./index.mjs",
   "types": "types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.cjs",
+      "default": "./index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "lint": "eslint src test",
     "test": "nyc --all mocha test",


### PR DESCRIPTION
## Summary

Enable usage in both ESM and CommonJS environments. Keeps CJS compatibility while clearly defining exports for import/require resolution.

## Changes

- Add: `index.mjs` that re-exports the CJS build as default and named.
- Keep: `index.cjs` pointing to `src/index.js`.
- Update: `package.json` for dual publish
  - main: `./index.cjs`, module: `./index.mjs`
  - exports with import/require/default
- Keep types: `types/index.d.ts`
